### PR TITLE
Use IHtmlString as the return type for Report and Token Extensions

### DIFF
--- a/sdk/PowerBI.AspNet.Mvc/Html/ReportExtensions.cs
+++ b/sdk/PowerBI.AspNet.Mvc/Html/ReportExtensions.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.PowerBI.Api;
+﻿using Microsoft.PowerBI.Api.V1.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Web.Mvc;
-using Microsoft.PowerBI.Api.V1.Models;
+using System.Web;
 
 namespace Microsoft.PowerBI.AspNet.Mvc.Html
 {
@@ -20,7 +20,7 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
         /// <param name="report">The Power BI report</param>
         /// <param name="htmlAttributes">Additional attributes used while rendering the report</param>
         /// <returns></returns>
-        public static MvcHtmlString PowerBIReport(this HtmlHelper htmlHelper, string name, Report report, object htmlAttributes = null)
+        public static IHtmlString PowerBIReport(this HtmlHelper htmlHelper, string name, Report report, object htmlAttributes = null)
         {
             return ReportHelper(htmlHelper, null, report, name, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
         }
@@ -33,7 +33,7 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
         /// <param name="embedUrl">The report embed url</param>
         /// <param name="htmlAttributes">Additional attributes used while rendering the report</param>
         /// <returns></returns>
-        public static MvcHtmlString PowerBIReport(this HtmlHelper htmlHelper, string name, string embedUrl, object htmlAttributes = null)
+        public static IHtmlString PowerBIReport(this HtmlHelper htmlHelper, string name, string embedUrl, object htmlAttributes = null)
         {
             var report = new Report { EmbedUrl = embedUrl };
             return ReportHelper(htmlHelper, null, report, name, HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
@@ -48,13 +48,13 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
         /// <param name="expression">The report expression</param>
         /// <param name="htmlAttributes">Additional attributes used while rendering the report</param>
         /// <returns></returns>
-        public static MvcHtmlString PowerBIReportFor<TModel, TProperty>(this HtmlHelper<TModel> htmlHelper, Expression<Func<TModel, TProperty>> expression, object htmlAttributes = null)
+        public static IHtmlString PowerBIReportFor<TModel, TProperty>(this HtmlHelper<TModel> htmlHelper, Expression<Func<TModel, TProperty>> expression, object htmlAttributes = null)
         {
             var modelMetadata = ModelMetadata.FromLambdaExpression<TModel, TProperty>(expression, htmlHelper.ViewData);
             return ReportHelper(htmlHelper, modelMetadata, modelMetadata.Model, ExpressionHelper.GetExpressionText(expression), HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
         }
 
-        private static MvcHtmlString ReportHelper(this HtmlHelper htmlHelper, ModelMetadata metadata, object value, string expression, IDictionary<string, object> htmlAttributes)
+        private static IHtmlString ReportHelper(this HtmlHelper htmlHelper, ModelMetadata metadata, object value, string expression, IDictionary<string, object> htmlAttributes)
         {
             var fullHtmlFieldName = htmlHelper.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(expression);
 
@@ -76,7 +76,7 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
             tagBuilder.MergeAttribute("powerbi-type", "report", true);
             tagBuilder.GenerateId(fullHtmlFieldName);
 
-            return new MvcHtmlString(tagBuilder.ToString(TagRenderMode.Normal));
+            return new HtmlString(tagBuilder.ToString(TagRenderMode.Normal));
         }
     }
 }

--- a/sdk/PowerBI.AspNet.Mvc/Html/TokenExtensions.cs
+++ b/sdk/PowerBI.AspNet.Mvc/Html/TokenExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.PowerBI.Security;
 using System;
 using System.Linq.Expressions;
+using System.Web;
 using System.Web.Mvc;
 
 namespace Microsoft.PowerBI.AspNet.Mvc.Html
@@ -16,7 +17,7 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
         /// <param name="htmlHelper">The html helper</param>
         /// <param name="accessToken">The access token to include</param>
         /// <returns></returns>
-        public static MvcHtmlString PowerBIAccessToken(this HtmlHelper htmlHelper, string accessToken = null)
+        public static IHtmlString PowerBIAccessToken(this HtmlHelper htmlHelper, string accessToken = null)
         {
             return TokenHelper(htmlHelper, accessToken);
         }
@@ -29,13 +30,13 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
         /// <typeparam name="TModel">The model type</typeparam>
         /// <typeparam name="TProperty">The property type</typeparam>
         /// <returns></returns>
-        public static MvcHtmlString PowerBIAccessTokenFor<TModel, TProperty>(this HtmlHelper<TModel> htmlHelper, Expression<Func<TModel, TProperty>> expression)
+        public static IHtmlString PowerBIAccessTokenFor<TModel, TProperty>(this HtmlHelper<TModel> htmlHelper, Expression<Func<TModel, TProperty>> expression)
         {
             var modelMetadata = ModelMetadata.FromLambdaExpression(expression, htmlHelper.ViewData);
             return TokenHelper(htmlHelper, modelMetadata.Model as string);
         }
 
-        private static MvcHtmlString TokenHelper(this HtmlHelper htmlHelper, string accessToken)
+        private static IHtmlString TokenHelper(this HtmlHelper htmlHelper, string accessToken)
         {
             if (string.IsNullOrWhiteSpace(accessToken))
             {
@@ -43,7 +44,7 @@ namespace Microsoft.PowerBI.AspNet.Mvc.Html
             }
 
             var script = $"<script>window.powerbi = window.powerbi || {{}};{Environment.NewLine}window.powerbi.accessToken = '{accessToken}';</script>";
-            return new MvcHtmlString(script);
+            return new HtmlString(script);
         }
     }
 }


### PR DESCRIPTION
Related #34. Extensions now declare their return type to be IHtmlString
rather than MvcHtmlString. The implementation of IHtmlString that is
actually created is irrelevant to the caller.