### PR TITLE
Fix typo in GatewayDatasource.credentialType description

### DIFF
--- a/sdk/swaggers/swagger.json
+++ b/sdk/swaggers/swagger.json
@@ -14962,7 +14962,7 @@
                 },
                 "credentialType": {
                     "type": "string",
-                    "description": "Type of the datasoruce credentials",
+                    "description": "Type of the datasource credentials",
                     "enum": [
                         "Basic",
                         "Windows",


### PR DESCRIPTION
## Description
Fixes a simple typo in the description of the GatewayDatasource.credentialType attribute.

## Question
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [ ] Bug Fixes?
- [ ] New Features?
- [x] Documentation?

### Is pull request totally generated from swagger file?
- [x] Yes.
- [ ] No, part of it is auto-generated.

### Backward compatibility break?
- [ ] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
