### PR TITLE
Added missing Measure/Column properties

### DIFF
--- a/sdk/PowerBI.Api/Source/Models/Column.cs
+++ b/sdk/PowerBI.Api/Source/Models/Column.cs
@@ -31,11 +31,24 @@ namespace Microsoft.PowerBI.Api.Models
         /// <param name="formatString">(Optional) The format of the column as
         /// specified in
         /// [FORMAT_STRING](https://docs.microsoft.com/analysis-services/multidimensional-models/mdx/mdx-cell-properties-format-string-contents)</param>
-        public Column(string name, string dataType, string formatString = default(string))
+        /// <param name="sortByColumn">(Optional) String name of a column in
+        /// the same table to be used to order the current column</param>
+        /// <param name="dataCategory">(Optional) String value to be used for
+        /// the data category which describes the data within this
+        /// column</param>
+        /// <param name="isHidden">(Optional) Property indicating if the column
+        /// is hidden from view. Default is false.</param>
+        /// <param name="summarizeBy">(Optional) Aggregate Function to use for
+        /// summarizing this column</param>
+        public Column(string name, string dataType, string formatString = default(string), string sortByColumn = default(string), string dataCategory = default(string), bool? isHidden = default(bool?), string summarizeBy = default(string))
         {
             Name = name;
             DataType = dataType;
             FormatString = formatString;
+            SortByColumn = sortByColumn;
+            DataCategory = dataCategory;
+            IsHidden = isHidden;
+            SummarizeBy = summarizeBy;
             CustomInit();
         }
 
@@ -62,6 +75,34 @@ namespace Microsoft.PowerBI.Api.Models
         /// </summary>
         [JsonProperty(PropertyName = "formatString")]
         public string FormatString { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) String name of a column in the same table
+        /// to be used to order the current column
+        /// </summary>
+        [JsonProperty(PropertyName = "sortByColumn")]
+        public string SortByColumn { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) String value to be used for the data
+        /// category which describes the data within this column
+        /// </summary>
+        [JsonProperty(PropertyName = "dataCategory")]
+        public string DataCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) Property indicating if the column is hidden
+        /// from view. Default is false.
+        /// </summary>
+        [JsonProperty(PropertyName = "isHidden")]
+        public bool? IsHidden { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) Aggregate Function to use for summarizing
+        /// this column
+        /// </summary>
+        [JsonProperty(PropertyName = "summarizeBy")]
+        public string SummarizeBy { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/sdk/PowerBI.Api/Source/Models/GatewayDatasource.cs
+++ b/sdk/PowerBI.Api/Source/Models/GatewayDatasource.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerBI.Api.Models
         /// </summary>
         /// <param name="id">The unique id for this datasource</param>
         /// <param name="gatewayId">The associated gateway id</param>
-        /// <param name="credentialType">Type of the datasoruce credentials.
+        /// <param name="credentialType">Type of the datasource credentials.
         /// Possible values include: 'Basic', 'Windows', 'Anonymous', 'OAuth2',
         /// 'Key'</param>
         /// <param name="datasourceName">The name of the datasource</param>
@@ -81,7 +81,7 @@ namespace Microsoft.PowerBI.Api.Models
         public string ConnectionDetails { get; set; }
 
         /// <summary>
-        /// Gets or sets type of the datasoruce credentials. Possible values
+        /// Gets or sets type of the datasource credentials. Possible values
         /// include: 'Basic', 'Windows', 'Anonymous', 'OAuth2', 'Key'
         /// </summary>
         [JsonProperty(PropertyName = "credentialType")]

--- a/sdk/PowerBI.Api/Source/Models/Measure.cs
+++ b/sdk/PowerBI.Api/Source/Models/Measure.cs
@@ -28,10 +28,18 @@ namespace Microsoft.PowerBI.Api.Models
         /// </summary>
         /// <param name="name">The measure name</param>
         /// <param name="expression">A valid DAX expression</param>
-        public Measure(string name, string expression)
+        /// <param name="formatString">(Optional) A string describing how the
+        /// value should be formatted when it is displayed as specified in
+        /// [FORMAT_STRING](https://docs.microsoft.com/analysis-services/multidimensional-models/mdx/mdx-cell-properties-format-string-contents)</param>
+        /// <param name="description">(Optional) Measure description</param>
+        /// <param name="isHidden">(Optional) Is measure hidden</param>
+        public Measure(string name, string expression, string formatString = default(string), string description = default(string), bool? isHidden = default(bool?))
         {
             Name = name;
             Expression = expression;
+            FormatString = formatString;
+            Description = description;
+            IsHidden = isHidden;
             CustomInit();
         }
 
@@ -51,6 +59,26 @@ namespace Microsoft.PowerBI.Api.Models
         /// </summary>
         [JsonProperty(PropertyName = "expression")]
         public string Expression { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) A string describing how the value should be
+        /// formatted when it is displayed as specified in
+        /// [FORMAT_STRING](https://docs.microsoft.com/analysis-services/multidimensional-models/mdx/mdx-cell-properties-format-string-contents)
+        /// </summary>
+        [JsonProperty(PropertyName = "formatString")]
+        public string FormatString { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) Measure description
+        /// </summary>
+        [JsonProperty(PropertyName = "description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets (Optional) Is measure hidden
+        /// </summary>
+        [JsonProperty(PropertyName = "isHidden")]
+        public bool? IsHidden { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/sdk/swaggers/swagger.json
+++ b/sdk/swaggers/swagger.json
@@ -14860,6 +14860,22 @@
                 "formatString": {
                     "type": "string",
                     "description": "(Optional) The format of the column as specified in [FORMAT_STRING](https://docs.microsoft.com/analysis-services/multidimensional-models/mdx/mdx-cell-properties-format-string-contents)"
+                },
+                "sortByColumn": {
+                    "type": "string",
+                    "description": "(Optional) String name of a column in the same table to be used to order the current column"
+                },
+                "dataCategory": {
+                    "type": "string",
+                    "description": "(Optional) String value to be used for the data category which describes the data within this column"
+                },
+                "isHidden": {
+                    "type": "boolean",
+                    "description": "(Optional) Property indicating if the column is hidden from view. Default is false."
+                },
+                "summarizeBy": {
+                    "type": "string",
+                    "description": "(Optional) Aggregate Function to use for summarizing this column"
                 }
             }
         },
@@ -14887,6 +14903,18 @@
                 "expression": {
                     "type": "string",
                     "description": "A valid DAX expression"
+                },
+                "formatString": {
+                    "type": "string",
+                    "description": "(Optional) A string describing how the value should be formatted when it is displayed as specified in [FORMAT_STRING](https://docs.microsoft.com/analysis-services/multidimensional-models/mdx/mdx-cell-properties-format-string-contents)"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "(Optional) Measure description"
+                },
+                "isHidden": {
+                    "type": "boolean",
+                    "description": "(Optional) Is measure hidden"
                 }
             }
         },


### PR DESCRIPTION
Added missing properties.
- Measure: isHidden, formatString
- Column: isHidden, summarizeBy, dataCategory, sortByColumn

## Description
These properties are supported by server APIs but are not included in the client libraries. 
See info here: [https://powerbi.microsoft.com/en-us/blog/newdatasets/](https://powerbi.microsoft.com/en-us/blog/newdatasets/)

## Questions
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [ ] Bug Fixes?
- [ ] New Features?
- [x] Documentation?

### Is pull request totally generated from swagger file?
- [x] Yes.
- [ ] No, part of it is auto-generated.

### Backward compatibility break?
- [ ] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
