### PR TITLE
make AsymmetricHigherKeyEncryptionHelper runnable on non-windows platforms

### DIFF
--- a/sdk/PowerBI.Api/Extensions/AsymmetricHigherKeyEncryptionHelper.cs
+++ b/sdk/PowerBI.Api/Extensions/AsymmetricHigherKeyEncryptionHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerBI.Api.Extensions
             Buffer.BlockCopy(keyMac, 0, keys, keyEnc.Length + 2, keyMac.Length);
             byte[] encryptedKeys;
 
-            using (var rsa = new RSACng())
+            using (var rsa = RSA.Create())
             {
                 var rsaKeyInfo = rsa.ExportParameters(false);
                 rsaKeyInfo.Modulus = modulusBytes;


### PR DESCRIPTION
## Description

Currently the AsymmetricHigherKeyEncryptionHelper extension relies on RSACng. As described [here](https://github.com/dotnet/core/issues/1918) CNG is a library that's only available on Windows so far. While trying to use the library on a dotnet core app running on Linux, the code compiled successfully, but resulted in the error described in the issue referenced earlier. As discussed in that same issue, a solution to that problem could be to use the base RSA class' `Create` method instead. So far this has worked for me successfully, as I was able to sent encrypted credentials to an on-premise gateway. This was in a copy-pasted version of that class, as this class, due to it being a `static class` and its `Encrypt` method being modified with the `internal`, could not be extended. 

The only concern with the above could be that the developer docs for RSACng [state](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rsacng?view=net-5.0) that RSACng is derived from the RSA class, and therefore the base class would not necessarily be a drop-in replacement for RSACng.

@ali-hamud @anant-k-singh Could you review? If you disagree with the above change, do you have suggestions on how to improve the code so that it can run properly on non-windows platforms?

## Question
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [x] Bug Fixes?
- [ ] New Features?
- [] Documentation?

### Is pull request totally generated from swagger file?
- [ ] Yes.
- [x] No, part of it is auto-generated.

### Backward compatibility break?
- [ ] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
