### PR TITLE
Bug 1979594

### DIFF
--- a/sdk/swaggers/swagger.json
+++ b/sdk/swaggers/swagger.json
@@ -10595,7 +10595,7 @@
                     },
                     "Get a list of workspaces using a filter example": {
                         "parameters": {
-                            "$filter": "$filter=contains(name,'marketing')%20or%20name%20eq%20'contoso'"
+                            "$filter": "contains(name,'marketing')%20or%20name%20eq%20'contoso'"
                         },
                         "responses": {
                             "200": {


### PR DESCRIPTION
https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1979594
## Description
Example had "$filter=" appearing twice. I fixed it.

## Question
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [X] Bug Fixes?
- [ ] New Features?
- [ ] Documentation?

### Is pull request totally generated from swagger file?
- [ ] Yes.
- [ ] No, part of it is auto-generated.

### Backward compatibility break?
- [ ] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
