### PR TITLE
Changed WorkflowInfoDatamart type to string to be in alignment with o…

### DIFF
--- a/sdk/PowerBI.Api/Source/Models/WorkspaceInfoDatamart.cs
+++ b/sdk/PowerBI.Api/Source/Models/WorkspaceInfoDatamart.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerBI.Api.Models
         /// <param name="datasourceUsages">The data source usages</param>
         /// <param name="users">The user access details for a Power BI
         /// datamart.</param>
-        public WorkspaceInfoDatamart(System.Guid id, string name = default(string), string description = default(string), DatamartType type = default(DatamartType), DatamartStatus1 status = default(DatamartStatus1), DatamartState state = default(DatamartState), string suspendedBatchId = default(string), EndorsementDetails endorsementDetails = default(EndorsementDetails), SensitivityLabel sensitivityLabel = default(SensitivityLabel), string modifiedBy = default(string), System.DateTime? modifiedDateTime = default(System.DateTime?), string configuredBy = default(string), string modifiedById = default(string), string configuredById = default(string), IList<DependentDataflow> upstreamDataflows = default(IList<DependentDataflow>), IList<DatasourceUsage> datasourceUsages = default(IList<DatasourceUsage>), IList<DatamartUser> users = default(IList<DatamartUser>))
+        public WorkspaceInfoDatamart(System.Guid id, string name = default(string), string description = default(string), string type = default(string), DatamartStatus1 status = default(DatamartStatus1), DatamartState state = default(DatamartState), string suspendedBatchId = default(string), EndorsementDetails endorsementDetails = default(EndorsementDetails), SensitivityLabel sensitivityLabel = default(SensitivityLabel), string modifiedBy = default(string), System.DateTime? modifiedDateTime = default(System.DateTime?), string configuredBy = default(string), string modifiedById = default(string), string configuredById = default(string), IList<DependentDataflow> upstreamDataflows = default(IList<DependentDataflow>), IList<DatasourceUsage> datasourceUsages = default(IList<DatasourceUsage>), IList<DatamartUser> users = default(IList<DatamartUser>))
         {
             Id = id;
             Name = name;
@@ -99,7 +99,7 @@ namespace Microsoft.PowerBI.Api.Models
         /// <summary>
         /// </summary>
         [JsonProperty(PropertyName = "type")]
-        public DatamartType Type { get; set; }
+        public string Type { get; set; }
 
         /// <summary>
         /// </summary>


### PR DESCRIPTION
## Description
I was experiencing a deserialization error when a workspace contained a datamart. This is due to the type object of WorkspaceInfoDatamart not being in alignment with how the JSON is structured. I have converted this type to a string to be in alignment with other objects such as WorkspaceInfoDataset and WorkspaceInfoReport.

NOTE: I did not modify the swagger file so if this change is approved this will need to be done.

Exception Info: 
JsonSerializationException: Error converting value "Sql" to type 'Microsoft.PowerBI.Api.Models.DatamartType'.

## Question
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [x ] Bug Fixes?
- [ ] New Features?
- [] Documentation?

### Is pull request totally generated from swagger file?
- [ ] Yes.
- [x] No, part of it is auto-generated.

### Backward compatibility break?
- [x] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
