### PR TITLE
Add subfolderId query parameter to POST ImportsOperations

### DIFF
--- a/sdk/PowerBI.Api.Tests/ImportsTests.cs
+++ b/sdk/PowerBI.Api.Tests/ImportsTests.cs
@@ -259,6 +259,23 @@ namespace PowerBI.Api.Tests
             }
         }
 
+        [TestMethod]
+        public async Task PostImportWithFileWithNameAndSubfolderId()
+        {
+            var datasetDisplayName = "TestDataset";
+            long subfolderId = 123;
+            var importResponse = CreateSampleImportResponse();
+
+            using (var handler = new FakeHttpClientHandler(importResponse))
+            using (var client = CreatePowerBIClient(handler))
+            using (var stream = new MemoryStream())
+            {
+                await client.Imports.PostImportWithFileAsync(stream, datasetDisplayName, subfolderId: subfolderId);
+                var expectedRequesetUrl = $"https://api.powerbi.com/v1.0/myorg/imports?datasetDisplayName={datasetDisplayName}&subfolderId={subfolderId}";
+                Assert.AreEqual(expectedRequesetUrl, handler.Request.RequestUri.ToString());
+            }
+        }
+
         private static HttpResponseMessage CreateSampleImportResponse(string name = default(string))
         {
             var import = new Import

--- a/sdk/PowerBI.Api/Extensions/ImportsOperationsExtensions.cs
+++ b/sdk/PowerBI.Api/Extensions/ImportsOperationsExtensions.cs
@@ -72,9 +72,12 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
-        public static Import PostImport(this IImportsOperations operations, Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?))
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
+        public static Import PostImport(this IImportsOperations operations, Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?))
         {
-            return operations.PostImportAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel).GetAwaiter().GetResult();
+            return operations.PostImportAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -104,12 +107,15 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<Import> PostImportAsync(this IImportsOperations operations, Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<Import> PostImportAsync(this IImportsOperations operations, Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (var _result = await operations.PostImportInGroupWithHttpMessagesAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, null, cancellationToken).ConfigureAwait(false))
+            using (var _result = await operations.PostImportInGroupWithHttpMessagesAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, null, cancellationToken).ConfigureAwait(false))
             {
                 return _result.Body;
             }
@@ -216,9 +222,12 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
-        public static Import PostImportWithFile(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?))
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
+        public static Import PostImportWithFile(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?))
         {
-            return Task.Factory.StartNew(s => ((IImportsOperations)s).PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult().Body;
+            return Task.Factory.StartNew(s => ((IImportsOperations)s).PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult().Body;
         }
 
         /// <summary>
@@ -249,12 +258,15 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<Import> PostImportWithFileAsync(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<Import> PostImportWithFileAsync(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (var _result = await operations.PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, null, cancellationToken).ConfigureAwait(false))
+            using (var _result = await operations.PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, null, cancellationToken).ConfigureAwait(false))
             {
                 return _result.Body;
             }

--- a/sdk/PowerBI.Api/Imports/IImportsOperations.cs
+++ b/sdk/PowerBI.Api/Imports/IImportsOperations.cs
@@ -34,10 +34,13 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name="customHeaders">Optional custom headers</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
         /// <returns></returns>
-        Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Uploads a PBIX file to the specified group
@@ -63,12 +66,15 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name="customHeaders">
         /// Optional custom headers
         /// </param>
         /// <param name="cancellationToken">
         /// Optional cancellation token
         /// </param>
-        Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/sdk/PowerBI.Api/Imports/ImportsOperations.cs
+++ b/sdk/PowerBI.Api/Imports/ImportsOperations.cs
@@ -54,13 +54,16 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name="customHeaders">
         /// Optional custom headers
         /// </param>
         /// <param name="cancellationToken">
         /// Optional cancellation token
         /// </param>
-        public async Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PostImportFileWithHttpMessage(
                             groupId: null,
@@ -70,6 +73,7 @@ namespace Microsoft.PowerBI.Api
                             skipReport: skipReport,
                             overrideReportLabel: overrideReportLabel,
                             overrideModelLabel: overrideModelLabel,
+                            subfolderId: subfolderId,
                             customHeaders: customHeaders,
                             cancellationToken: cancellationToken);
         }
@@ -98,13 +102,16 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name="customHeaders">
         /// Optional custom headers
         /// </param>
         /// <param name="cancellationToken">
         /// Optional cancellation token
         /// </param>
-        public async Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<Import>> PostImportFileWithHttpMessage(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Tracing
             string _invocationId = null;
@@ -119,6 +126,7 @@ namespace Microsoft.PowerBI.Api
                 tracingParameters.Add("skipReport", skipReport);
                 tracingParameters.Add("overrideReportLabel", overrideReportLabel);
                 tracingParameters.Add("overrideModelLabel", overrideModelLabel);
+                tracingParameters.Add("subfolderId", subfolderId);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "PostImport", tracingParameters);
             }
@@ -135,15 +143,15 @@ namespace Microsoft.PowerBI.Api
 
             if (file.Length > 1 * GB)
             {
-                return await UploadLargeFile(groupId, file, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, customHeaders, cancellationToken);
+                return await UploadLargeFile(groupId, file, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, customHeaders, cancellationToken);
             }
             else
             {
-                return await UploadFile(groupId, file, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, customHeaders, cancellationToken);
+                return await UploadFile(groupId, file, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, customHeaders, cancellationToken);
             }
         }
 
-        private async Task<HttpOperationResponse<Import>> UploadFile(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<HttpOperationResponse<Import>> UploadFile(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
@@ -178,6 +186,10 @@ namespace Microsoft.PowerBI.Api
             if (overrideModelLabel != null)
             {
                 _queryParameters.Add(string.Format("overrideModelLabel={0}", overrideModelLabel));
+            }
+            if (subfolderId != null)
+            {
+                _queryParameters.Add(string.Format("subfolderId={0}", subfolderId));
             }
 
             if (_queryParameters.Count > 0)
@@ -279,7 +291,7 @@ namespace Microsoft.PowerBI.Api
         }
 
 
-        private async Task<HttpOperationResponse<Import>> UploadLargeFile(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<HttpOperationResponse<Import>> UploadLargeFile(Guid? groupId, Stream file, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             TemporaryUploadLocation temporaryUploadLocation;
 
@@ -312,11 +324,11 @@ namespace Microsoft.PowerBI.Api
 
                 if (groupId == null)
                 {
-                    return await powerBIClient.Imports.PostImportWithHttpMessagesAsync(datasetDisplayName, new ImportInfo { FileUrl = temporaryUploadLocation.Url }, nameConflict, skipReport, overrideReportLabel, overrideModelLabel);
+                    return await powerBIClient.Imports.PostImportWithHttpMessagesAsync(datasetDisplayName, new ImportInfo { FileUrl = temporaryUploadLocation.Url }, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId);
                 }
                 else
                 {
-                    return await powerBIClient.Imports.PostImportInGroupWithHttpMessagesAsync(groupId.Value, datasetDisplayName, new ImportInfo { FileUrl = temporaryUploadLocation.Url }, nameConflict, skipReport, overrideReportLabel, overrideModelLabel);
+                    return await powerBIClient.Imports.PostImportInGroupWithHttpMessagesAsync(groupId.Value, datasetDisplayName, new ImportInfo { FileUrl = temporaryUploadLocation.Url }, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId);
                 }
             }
         }

--- a/sdk/PowerBI.Api/Imports/ImportsOperationsExtensions.cs
+++ b/sdk/PowerBI.Api/Imports/ImportsOperationsExtensions.cs
@@ -35,9 +35,12 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
-        public static Import PostImportWithFileInGroup(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?))
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
+        public static Import PostImportWithFileInGroup(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?))
         {
-            return Task.Factory.StartNew(s => ((IImportsOperations)s).PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel: overrideReportLabel, overrideModelLabel: overrideModelLabel), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult().Body;
+            return Task.Factory.StartNew(s => ((IImportsOperations)s).PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel: overrideReportLabel, overrideModelLabel: overrideModelLabel, subfolderId: subfolderId), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult().Body;
         }
 
         /// <summary>
@@ -67,12 +70,15 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<Import> PostImportWithFileAsyncInGroup(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<Import> PostImportWithFileAsyncInGroup(this IImportsOperations operations, Guid groupId, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (var _result = await operations.PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, null, cancellationToken).ConfigureAwait(false))
+            using (var _result = await operations.PostImportFileWithHttpMessage(groupId, fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, null, cancellationToken).ConfigureAwait(false))
             {
                 return _result.Body;
             }
@@ -102,9 +108,12 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
-        public static Import PostImportWithFile(this IImportsOperations operations, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?))
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
+        public static Import PostImportWithFile(this IImportsOperations operations, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?))
         {
-            return Task.Factory.StartNew(s => ((IImportsOperations)s).PostImportFileWithHttpMessage(fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult().Body;
+            return Task.Factory.StartNew(s => ((IImportsOperations)s).PostImportFileWithHttpMessage(fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult().Body;
         }
 
         /// <summary>
@@ -131,12 +140,15 @@ namespace Microsoft.PowerBI.Api
         /// <param name='overrideModelLabel'>
         /// Determines whether to override existing label on model during republish of PBIX file, service default value is true.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<Import> PostImportWithFileAsync(this IImportsOperations operations, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<Import> PostImportWithFileAsync(this IImportsOperations operations, Stream fileStream, string datasetDisplayName = default(string), ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (var _result = await operations.PostImportFileWithHttpMessage(fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, null, cancellationToken).ConfigureAwait(false))
+            using (var _result = await operations.PostImportFileWithHttpMessage(fileStream, datasetDisplayName, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, null, cancellationToken).ConfigureAwait(false))
             {
                 return _result.Body;
             }

--- a/sdk/PowerBI.Api/Source/IImportsOperations.cs
+++ b/sdk/PowerBI.Api/Source/IImportsOperations.cs
@@ -114,6 +114,9 @@ namespace Microsoft.PowerBI.Api
         /// Whether to override the existing label on a model when republishing
         /// a Power BI .pbix file. The service default value is `true`.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
@@ -129,7 +132,7 @@ namespace Microsoft.PowerBI.Api
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<Import>> PostImportWithHttpMessagesAsync(string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<Import>> PostImportWithHttpMessagesAsync(string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns the specified import from **My workspace**.
         /// </summary>
@@ -323,6 +326,9 @@ namespace Microsoft.PowerBI.Api
         /// republishing a Power BI .pbix file. The service default value is
         /// `true`.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
@@ -338,7 +344,7 @@ namespace Microsoft.PowerBI.Api
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<Import>> PostImportInGroupWithHttpMessagesAsync(System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<Import>> PostImportInGroupWithHttpMessagesAsync(System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns the specified import from the specified workspace.
         /// </summary>

--- a/sdk/PowerBI.Api/Source/ImportsOperations.cs
+++ b/sdk/PowerBI.Api/Source/ImportsOperations.cs
@@ -251,6 +251,9 @@ namespace Microsoft.PowerBI.Api
         /// Whether to override the existing label on a model when republishing a Power
         /// BI .pbix file. The service default value is `true`.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>
@@ -272,7 +275,7 @@ namespace Microsoft.PowerBI.Api
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<Import>> PostImportWithHttpMessagesAsync(string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<Import>> PostImportWithHttpMessagesAsync(string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (datasetDisplayName == null)
             {
@@ -294,6 +297,7 @@ namespace Microsoft.PowerBI.Api
                 tracingParameters.Add("skipReport", skipReport);
                 tracingParameters.Add("overrideReportLabel", overrideReportLabel);
                 tracingParameters.Add("overrideModelLabel", overrideModelLabel);
+                tracingParameters.Add("subfolderId", subfolderId);
                 tracingParameters.Add("importInfo", importInfo);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "PostImport", tracingParameters);
@@ -321,6 +325,10 @@ namespace Microsoft.PowerBI.Api
             if (overrideModelLabel != null)
             {
                 _queryParameters.Add(string.Format("overrideModelLabel={0}", System.Uri.EscapeDataString(Rest.Serialization.SafeJsonConvert.SerializeObject(overrideModelLabel, Client.SerializationSettings).Trim('"'))));
+            }
+            if (subfolderId != null)
+            {
+                _queryParameters.Add(string.Format("subfolderId={0}", System.Uri.EscapeDataString(Rest.Serialization.SafeJsonConvert.SerializeObject(subfolderId, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
@@ -964,6 +972,9 @@ namespace Microsoft.PowerBI.Api
         /// Determines whether to override the existing label on a model when
         /// republishing a Power BI .pbix file. The service default value is `true`.
         /// </param>
+        /// <param name="subfolderId">
+        /// The subfolder id to import the file to subfolder
+        /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>
@@ -985,7 +996,7 @@ namespace Microsoft.PowerBI.Api
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<Import>> PostImportInGroupWithHttpMessagesAsync(System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<Import>> PostImportInGroupWithHttpMessagesAsync(System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (datasetDisplayName == null)
             {
@@ -1008,6 +1019,7 @@ namespace Microsoft.PowerBI.Api
                 tracingParameters.Add("skipReport", skipReport);
                 tracingParameters.Add("overrideReportLabel", overrideReportLabel);
                 tracingParameters.Add("overrideModelLabel", overrideModelLabel);
+                tracingParameters.Add("subfolderId", subfolderId);
                 tracingParameters.Add("importInfo", importInfo);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "PostImportInGroup", tracingParameters);
@@ -1036,6 +1048,10 @@ namespace Microsoft.PowerBI.Api
             if (overrideModelLabel != null)
             {
                 _queryParameters.Add(string.Format("overrideModelLabel={0}", System.Uri.EscapeDataString(Rest.Serialization.SafeJsonConvert.SerializeObject(overrideModelLabel, Client.SerializationSettings).Trim('"'))));
+            }
+            if (subfolderId != null)
+            {
+                _queryParameters.Add(string.Format("subfolderId={0}", System.Uri.EscapeDataString(Rest.Serialization.SafeJsonConvert.SerializeObject(subfolderId, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {

--- a/sdk/PowerBI.Api/Source/ImportsOperationsExtensions.cs
+++ b/sdk/PowerBI.Api/Source/ImportsOperationsExtensions.cs
@@ -132,9 +132,12 @@ namespace Microsoft.PowerBI.Api
             /// Whether to override the existing label on a model when republishing a Power
             /// BI .pbix file. The service default value is `true`.
             /// </param>
-            public static Import PostImport(this IImportsOperations operations, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?))
+            /// <param name="subfolderId">
+            /// The subfolder id to import the file to subfolder
+            /// </param>
+            public static Import PostImport(this IImportsOperations operations, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?))
             {
-                return operations.PostImportAsync(datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel).GetAwaiter().GetResult();
+                return operations.PostImportAsync(datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -212,12 +215,15 @@ namespace Microsoft.PowerBI.Api
             /// Whether to override the existing label on a model when republishing a Power
             /// BI .pbix file. The service default value is `true`.
             /// </param>
+            /// <param name="subfolderId">
+            /// The subfolder id to import the file to subfolder
+            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<Import> PostImportAsync(this IImportsOperations operations, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<Import> PostImportAsync(this IImportsOperations operations, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.PostImportWithHttpMessagesAsync(datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.PostImportWithHttpMessagesAsync(datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }
@@ -505,9 +511,12 @@ namespace Microsoft.PowerBI.Api
             /// Determines whether to override the existing label on a model when
             /// republishing a Power BI .pbix file. The service default value is `true`.
             /// </param>
-            public static Import PostImportInGroup(this IImportsOperations operations, System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?))
+            /// <param name="subfolderId">
+            /// The subfolder id to import the file to subfolder
+            /// </param>/// 
+            public static Import PostImportInGroup(this IImportsOperations operations, System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?))
             {
-                return operations.PostImportInGroupAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel).GetAwaiter().GetResult();
+                return operations.PostImportInGroupAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -596,12 +605,15 @@ namespace Microsoft.PowerBI.Api
             /// Determines whether to override the existing label on a model when
             /// republishing a Power BI .pbix file. The service default value is `true`.
             /// </param>
+            /// <param name="subfolderId">
+            /// The subfolder id to import the file to subfolder
+            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<Import> PostImportInGroupAsync(this IImportsOperations operations, System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<Import> PostImportInGroupAsync(this IImportsOperations operations, System.Guid groupId, string datasetDisplayName, ImportInfo importInfo, ImportConflictHandlerMode? nameConflict = default(ImportConflictHandlerMode?), bool? skipReport = default(bool?), bool? overrideReportLabel = default(bool?), bool? overrideModelLabel = default(bool?), long? subfolderId = default(long?), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.PostImportInGroupWithHttpMessagesAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.PostImportInGroupWithHttpMessagesAsync(groupId, datasetDisplayName, importInfo, nameConflict, skipReport, overrideReportLabel, overrideModelLabel, subfolderId, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }

--- a/sdk/swaggers/swagger.json
+++ b/sdk/swaggers/swagger.json
@@ -2882,6 +2882,13 @@
                         "type": "boolean"
                     },
                     {
+                        "name": "subfolderId",
+                        "in": "query",
+                        "required": false,
+                        "description": "The subfolder id to import the file to subfolder",
+                        "type": "integer"
+                    },
+                    {
                         "name": "importInfo",
                         "in": "body",
                         "description": "The import to post",
@@ -6959,6 +6966,13 @@
                         "required": false,
                         "description": "Determines whether to override the existing label on a model when republishing a Power BI .pbix file. The service default value is `true`.",
                         "type": "boolean"
+                    },
+                    {
+                        "name": "subfolderId",
+                        "in": "query",
+                        "required": false,
+                        "description": "The subfolder id to import the file to subfolder",
+                        "type": "integer"
                     },
                     {
                         "name": "importInfo",


### PR DESCRIPTION
## Description
This pull request is required to be able to add a subfolderId when publishing reports.

## Question

### What inside?
- [ ] Bug Fixes?
- [x] New Features?
- [x] Documentation?

### Is pull request totally generated from swagger file?
- [ ] Yes.
- [x] No, part of it is auto-generated.

### Backward compatibility break?
- [x] Yes. Pull request breaks backward compatibility!
