### PR TITLE
Expression should be string type for workspace info scan

### DIFF
--- a/sdk/PowerBI.Api/Source/Models/Expression.cs
+++ b/sdk/PowerBI.Api/Source/Models/Expression.cs
@@ -28,7 +28,8 @@ namespace Microsoft.PowerBI.Api.Models
         /// </summary>
         /// <param name="name">The expression name</param>
         /// <param name="description">The expression description</param>
-        public Expression(ASMashupExpression expressionProperty, string name = default(string), string description = default(string))
+        /// <param name="expressionProperty">The expression</param>
+        public Expression(string expressionProperty = default(string), string name = default(string), string description = default(string))
         {
             ExpressionProperty = expressionProperty;
             Name = name;
@@ -44,7 +45,7 @@ namespace Microsoft.PowerBI.Api.Models
         /// <summary>
         /// </summary>
         [JsonProperty(PropertyName = "expression")]
-        public ASMashupExpression ExpressionProperty { get; set; }
+        public string ExpressionProperty { get; set; }
 
         /// <summary>
         /// Gets or sets the expression name
@@ -57,23 +58,5 @@ namespace Microsoft.PowerBI.Api.Models
         /// </summary>
         [JsonProperty(PropertyName = "description")]
         public string Description { get; set; }
-
-        /// <summary>
-        /// Validate the object.
-        /// </summary>
-        /// <exception cref="ValidationException">
-        /// Thrown if validation fails
-        /// </exception>
-        public virtual void Validate()
-        {
-            if (ExpressionProperty == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "ExpressionProperty");
-            }
-            if (ExpressionProperty != null)
-            {
-                ExpressionProperty.Validate();
-            }
-        }
     }
 }


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**UNTESTED**

I could not raise an issue, so here's a basic PR example.

There is a bug for WorkspaceInfoScan since version 4.11.0. When triggering a scan:

```csharp
var scan = await powerBIClient.WorkspaceInfo.PostWorkspaceInfoWithHttpMessagesAsync(requiredWorkspaces, true, true, true, true, true, cancellationToken: cancellationToken);
```

Then retrieving result:

```csharp
var response = await powerBIClient.WorkspaceInfo.GetScanResultWithHttpMessagesAsync(scanId, cancellationToken: cancellationToken);
```

Results in following exception:

```
Exception: Microsoft.Rest.SerializationException: Unable to deserialize the response.
at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
---> Newtonsoft.Json.JsonSerializationException: Error converting value "let
    Source = AnalysisServices.Database("powerbi://***"),
    Cubes = Table.Combine(Source[Data]),
    Cube = Cubes{[Id="Model", Kind="Cube"]}[Data]
in
    Cube" to type 'Microsoft.PowerBI.Api.Models.ASMashupExpression'. Path 'workspaces[1].datasets[0].expressions[0].expression', line 1, position 453138.
--- End of inner exception stack trace ---
---> System.ArgumentException: Could not cast or convert from System.String to Microsoft.PowerBI.Api.Models.ASMashupExpression.
```

## Question
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [x] Bug Fixes?
- [ ] New Features?
- [ ] Documentation?

### Is pull request totally generated from swagger file?
- [ ] Yes.
- [] No, part of it is auto-generated.

### Backward compatibility break?
- [ ] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
