### PR TITLE
Fix casing of IsRefreshable in Dataset.Serialization.cs

### DIFF
--- a/sdk/PowerBI.Api/Source/Models/AdminDataset.Serialization.cs
+++ b/sdk/PowerBI.Api/Source/Models/AdminDataset.Serialization.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerBI.Api.Models
             }
             if (Optional.IsDefined(Encryption))
             {
-                writer.WritePropertyName("Encryption"u8);
+                writer.WritePropertyName("encryption"u8);
                 writer.WriteObjectValue(Encryption);
             }
             if (Optional.IsCollectionDefined(Users))
@@ -208,7 +208,7 @@ namespace Microsoft.PowerBI.Api.Models
                     isOnPremGatewayRequired = property.Value.GetBoolean();
                     continue;
                 }
-                if (property.NameEquals("Encryption"u8))
+                if (property.NameEquals("encryption"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {

--- a/sdk/PowerBI.Api/Source/Models/Dataset.Serialization.cs
+++ b/sdk/PowerBI.Api/Source/Models/Dataset.Serialization.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerBI.Api.Models
             }
             if (Optional.IsDefined(Encryption))
             {
-                writer.WritePropertyName("Encryption"u8);
+                writer.WritePropertyName("encryption"u8);
                 writer.WriteObjectValue(Encryption);
             }
             if (Optional.IsCollectionDefined(Users))
@@ -202,7 +202,7 @@ namespace Microsoft.PowerBI.Api.Models
                     isOnPremGatewayRequired = property.Value.GetBoolean();
                     continue;
                 }
-                if (property.NameEquals("Encryption"u8))
+                if (property.NameEquals("encryption"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {

--- a/sdk/PowerBI.Api/Source/Models/DatasetSecurityProperties.Serialization.cs
+++ b/sdk/PowerBI.Api/Source/Models/DatasetSecurityProperties.Serialization.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerBI.Api.Models
             }
             if (Optional.IsDefined(Encryption))
             {
-                writer.WritePropertyName("Encryption"u8);
+                writer.WritePropertyName("encryption"u8);
                 writer.WriteObjectValue(Encryption);
             }
             writer.WriteEndObject();
@@ -78,7 +78,7 @@ namespace Microsoft.PowerBI.Api.Models
                     isOnPremGatewayRequired = property.Value.GetBoolean();
                     continue;
                 }
-                if (property.NameEquals("Encryption"u8))
+                if (property.NameEquals("encryption"u8))
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {

--- a/sdk/swaggers/swagger.json
+++ b/sdk/swaggers/swagger.json
@@ -23228,7 +23228,7 @@
                     "type": "boolean",
                     "description": "Whether the dataset requires an on-premises data gateway"
                 },
-                "Encryption": {
+                "encryption": {
                     "$ref": "#/definitions/Encryption",
                     "description": "Dataset encryption information. Only applicable when `$expand` is specified."
                 }


### PR DESCRIPTION
## Description
A regression occurred in the v5 release of the PowerBI SDK. The casing of various properties in `DataSet` are wrong.

v4:
```csharp
#:property PublishAot=false

#:package Microsoft.Identity.Client@4.79.2
#:package Microsoft.PowerBI.Api@4.22.0

using Microsoft.Identity.Client;
using Microsoft.PowerBI.Api;
using Microsoft.Rest;

var clientId = Environment.GetEnvironmentVariable("POWERBI_CLIENT_ID") ?? throw new InvalidOperationException("POWERBI_CLIENT_ID environment variable is not set.");
var clientSecret = Environment.GetEnvironmentVariable("POWERBI_CLIENT_SECRET") ?? throw new InvalidOperationException("POWERBI_CLIENT_SECRET environment variable is not set.");
var tenant = Environment.GetEnvironmentVariable("POWERBI_CLIENT_TENANT") ?? throw new InvalidOperationException("POWERBI_CLIENT_TENANT environment variable is not set.");
Guid workspaceId = Environment.GetEnvironmentVariable("POWERBI_WORKSPACE_ID") is string workspaceIdString && Guid.TryParse(workspaceIdString, out var wsId) ? wsId : throw new InvalidOperationException("POWERBI_WORKSPACE_ID environment variable is not set or is not a valid GUID.");

var authenticationResult = await ConfidentialClientApplicationBuilder
    .Create(clientId)
    .WithClientSecret(clientSecret)
    .WithAuthority($"https://login.microsoftonline.com/{tenant}")
    .Build()
    .AcquireTokenForClient(["https://analysis.windows.net/powerbi/api/.default"]).ExecuteAsync();

var powerBiClient = new PowerBIClient(new Uri("https://api.powerbi.com"), new TokenCredentials(authenticationResult.AccessToken, authenticationResult.TokenType));

var dataSets = (await powerBiClient.Datasets.GetDatasetsInGroupAsync(workspaceId)).Value.ToDictionary(x => x.Id);

foreach (var dataset in dataSets.Values)
{
    Console.WriteLine($"id: {dataset.Id} - IsEffectiveIdentityRequired: {dataset.IsEffectiveIdentityRequired} - IsRefreshable: {dataset.IsRefreshable}");
}
```

Output: `id: <guid> - IsEffectiveIdentityRequired: False - IsRefreshable: True`

v5:
```csharp
#:property PublishAot=false
#:package Azure.Identity@1.17.1
#:package Microsoft.PowerBI.Api@5.0.0

using System.Diagnostics;
using Azure.Identity;
using Microsoft.PowerBI.Api;

Console.WriteLine("Power BI SDK 5.x example");

var clientId = Environment.GetEnvironmentVariable("POWERBI_CLIENT_ID") ?? throw new InvalidOperationException("POWERBI_CLIENT_ID environment variable is not set.");
var clientSecret = Environment.GetEnvironmentVariable("POWERBI_CLIENT_SECRET") ?? throw new InvalidOperationException("POWERBI_CLIENT_SECRET environment variable is not set.");
var tenant = Environment.GetEnvironmentVariable("POWERBI_CLIENT_TENANT") ?? throw new InvalidOperationException("POWERBI_CLIENT_TENANT environment variable is not set.");
Guid workspaceId = Environment.GetEnvironmentVariable("POWERBI_WORKSPACE_ID") is string workspaceIdString && Guid.TryParse(workspaceIdString, out var wsId) ? wsId : throw new InvalidOperationException("POWERBI_WORKSPACE_ID environment variable is not set or is not a valid GUID.");

PowerBIClient client = new(new ClientSecretCredential(tenant, clientId, clientSecret));

var dataSets = (await client.Datasets.GetDatasetsInGroupAsync(workspaceId)).Value.Value.ToDictionary(x => x.Id);
foreach (var dataset in dataSets.Values)
{
    Console.WriteLine($"id: {dataset.Id} - IsEffectiveIdentityRequired: {dataset.IsEffectiveIdentityRequired} - IsRefreshable: {dataset.IsRefreshable}");
}
```

Output: `id: <guid> - IsEffectiveIdentityRequired:  - IsRefreshable: `

As you can see, the properties are lost.

## Question
please answer the following questions. put x inside [ ] (e.g. [x])

### What inside?
- [x] Bug Fixes?
- [ ] New Features?
- [ ] Documentation?

### Is pull request totally generated from swagger file?
- [x] Yes.
- [ ] No, part of it is auto-generated.

### Backward compatibility break?
- [ ] Yes. Pull request breaks backward compatibility!

[Learn more about backward compatibility.](BackwardCompatibility.md)
